### PR TITLE
Remove replace operation limit

### DIFF
--- a/GDSavefileFix.py
+++ b/GDSavefileFix.py
@@ -61,7 +61,7 @@ def main():
             decompressed_data = zlib.decompress(decoded_data[10:], -zlib.MAX_WBITS)
 
             # fix (i don't know why simply add spaces works...)
-            decompressed_data = decompressed_data.replace(b'><', b'> <', 50)
+            decompressed_data = decompressed_data.replace(b'><', b'> <')
 
             # encrypt
             compressed_data = zlib.compress(decompressed_data)


### PR DESCRIPTION
The replace method had a limit to replace only 50 instances of `><` which didn't fix my save files, removing the limit did fix them however.